### PR TITLE
Restrict arithmetic operator

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -259,6 +259,7 @@
       "type": "object",
       "default": {},
       "additionalProperties": false,
+      "required": ["name"],
       "properties": {
         "name": {
           "description": "Name of the mutation level.",
@@ -310,6 +311,7 @@
       "title": "ArithmeticOperator",
       "type": "array",
       "uniqueItems": true,
+      "minItems": 1,
       "default": [],
       "items": {
         "anyOf": [
@@ -347,6 +349,7 @@
       "description": "EmptyArray := \nEmptyConstructor := ",
       "uniqueItems": true,
       "default": [],
+      "minItems": 1,
       "items": {
         "anyOf": [
           {
@@ -373,6 +376,7 @@
       "type": "array",
       "uniqueItems": true,
       "default": [],
+      "minItems": 1,
       "items": {
         "anyOf": [
           {
@@ -398,6 +402,7 @@
       "type": "array",
       "default": [],
       "uniqueItems": true,
+      "minItems": 1,
       "items": {
         "anyOf": [
           {
@@ -443,6 +448,7 @@
       "type": "array",
       "uniqueItems": true,
       "default": [],
+      "minItems": 1,
       "items": {
         "anyOf": [
           {
@@ -512,6 +518,7 @@
       "title": "LogicalOperator",
       "type": "array",
       "default": [],
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "anyOf": [
@@ -537,6 +544,7 @@
       "title": "MethodExpression",
       "type": "array",
       "default": [],
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "anyOf": [
@@ -623,6 +631,7 @@
       "title": "OptionalChaining",
       "type": "array",
       "default": [],
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "anyOf": [
@@ -648,6 +657,7 @@
       "title": "StringLiteral",
       "type": "array",
       "default": [],
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "anyOf": [
@@ -673,6 +683,7 @@
       "title": "UnaryOperator",
       "type": "array",
       "default": [],
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "anyOf": [
@@ -698,6 +709,7 @@
       "title": "UpdateOperator",
       "type": "array",
       "default": [],
+      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "anyOf": [

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -258,7 +258,6 @@
       "title": "MutationLevel",
       "type": "object",
       "default": {},
-      "additionalProperties": false,
       "required": ["name"],
       "properties": {
         "name": {

--- a/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
+++ b/packages/instrumenter/src/mutators/arithmetic-operator-mutator.ts
@@ -10,7 +10,7 @@ const arithmeticOperatorReplacements = Object.freeze({
   '+': { replacement: '-', mutatorName: '+To-' },
   '-': { replacement: '+', mutatorName: '-To+' },
   '*': { replacement: '/', mutatorName: '*To/' },
-  '/': { replacement: '/', mutatorName: '/To*' },
+  '/': { replacement: '*', mutatorName: '/To*' },
   '%': { replacement: '*', mutatorName: '%To*' },
 } as const);
 
@@ -28,6 +28,7 @@ export const arithmeticOperatorMutator: NodeMutator = {
 };
 
 function isInMutationLevel(node: types.BinaryExpression, level?: MutationLevel): boolean {
+  // No mutation level specified, so allow everything
   if (level === undefined) {
     return true;
   }

--- a/packages/instrumenter/src/mutators/node-mutator.ts
+++ b/packages/instrumenter/src/mutators/node-mutator.ts
@@ -1,6 +1,7 @@
 import type { types, NodePath } from '@babel/core';
+import { MutationLevel } from '@stryker-mutator/api/core';
 
 export interface NodeMutator {
-  mutate(path: NodePath): Iterable<types.Node>;
+  mutate(path: NodePath, mutationOptions?: MutationLevel): Iterable<types.Node>;
   readonly name: string;
 }

--- a/packages/instrumenter/src/transformers/babel-transformer.ts
+++ b/packages/instrumenter/src/transformers/babel-transformer.ts
@@ -156,7 +156,7 @@ export const transformBabel: AstTransformer<ScriptFormat> = (
    */
   function* mutate(node: NodePath): Iterable<Mutable> {
     for (const mutator of mutators) {
-      for (const replacement of mutator.mutate(node)) {
+      for (const replacement of mutator.mutate(node, options.runLevel)) {
         yield {
           replacement,
           mutatorName: mutator.name,

--- a/packages/instrumenter/test/helpers/expect-mutation.ts
+++ b/packages/instrumenter/test/helpers/expect-mutation.ts
@@ -3,6 +3,8 @@ import { parse, ParserPlugin } from '@babel/parser';
 import generator from '@babel/generator';
 import { expect } from 'chai';
 
+import { MutationLevel } from '@stryker-mutator/api/core';
+
 import { NodeMutator } from '../../src/mutators/node-mutator.js';
 
 const generate = generator.default;
@@ -36,6 +38,15 @@ const plugins = [
 ] as ParserPlugin[];
 
 export function expectJSMutation(sut: NodeMutator, originalCode: string, ...expectedReplacements: string[]): void {
+  expectJSMutationWithLevel(sut, undefined, originalCode, ...expectedReplacements);
+}
+
+export function expectJSMutationWithLevel(
+  sut: NodeMutator,
+  level: MutationLevel | undefined,
+  originalCode: string,
+  ...expectedReplacements: string[]
+): void {
   const sourceFileName = 'source.js';
   const ast = parse(originalCode, {
     sourceFilename: sourceFileName,
@@ -47,7 +58,7 @@ export function expectJSMutation(sut: NodeMutator, originalCode: string, ...expe
 
   babel.traverse(ast, {
     enter(path) {
-      for (const replacement of sut.mutate(path)) {
+      for (const replacement of sut.mutate(path, level)) {
         const mutatedCode = generate(replacement).code;
         const beforeMutatedCode = originalCode.substring(0, path.node.start ?? 0);
         const afterMutatedCode = originalCode.substring(path.node.end ?? 0);

--- a/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/arithmatic-operator-mutator.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 
+import { MutationLevel } from '@stryker-mutator/api/core';
+
 import { arithmeticOperatorMutator as sut } from '../../../src/mutators/arithmetic-operator-mutator.js';
-import { expectJSMutation } from '../../helpers/expect-mutation.js';
+import { expectJSMutation, expectJSMutationWithLevel } from '../../helpers/expect-mutation.js';
+
+const arithmeticLevel: MutationLevel = { name: 'ArithemticLevel', ArithmeticOperator: ['+To-', '-To+', '*To/'] };
 
 describe(sut.name, () => {
   it('should have name "ArithmeticOperator"', () => {
@@ -29,5 +33,16 @@ describe(sut.name, () => {
     expectJSMutation(sut, '3 + `a`');
 
     expectJSMutation(sut, '"a" + b + "c" + d + "e"');
+  });
+
+  it('should only mutate +, - and * from all possible mutators', () => {
+    expectJSMutationWithLevel(
+      sut,
+      arithmeticLevel,
+      'a + b; a - b; a * b; a % b; a / b; a % b',
+      'a - b; a - b; a * b; a % b; a / b; a % b', // mutates +
+      'a + b; a + b; a * b; a % b; a / b; a % b', // mutates -
+      'a + b; a - b; a / b; a % b; a / b; a % b', // mutates *
+    );
   });
 });

--- a/testing-project/stryker.conf.json
+++ b/testing-project/stryker.conf.json
@@ -18,7 +18,7 @@
   "mutationLevels": [
     { 
       "name": "default",
-      "ArithmeticOperator": ["%To*"],
+      "ArithmeticOperator": ["+To-", "-To+", "*To/"],
       "ArrayDeclaration": ["EmptyArray"]
     },
     {


### PR DESCRIPTION
I'm curious if you have any other ways to level configuration to the mutator (what I did in `packages/instrumenter/src/mutators/node-mutator.ts)`