### PR TITLE
Added support for arrowfunction

### DIFF
--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -271,6 +271,9 @@
         "ArrayDeclaration": {
           "$ref": "#/definitions/ArrayDeclaration"
         },
+        "ArrowFunction": {
+          "$ref": "#/definitions/ArrowFunction"
+        },
         "BlockStatement": {
           "$ref": "#/definitions/BlockStatement"
         },
@@ -370,6 +373,23 @@
             "const": "FilledArrayConstructor",
             "title": "FilledArrayConstructorMutator",
             "description": "Replace ```new Array([1, 2, 3, 4])``` with ```new Array()```."
+          }
+        ]
+      }
+    },
+    "ArrowFunction": {
+      "title": "ArrowFunction",
+      "type": "array",
+      "description": "Mutates bodies of arrow functions to undefined",
+      "uniqueItems": true,
+      "default": [],
+      "minItems": 1,
+      "items": {
+        "anyOf": [
+          {
+            "const": "BodyToUndefined",
+            "title": "BodyToUndefinedMutator",
+            "description": "Replace body to ```undefined```."
           }
         ]
       }

--- a/packages/api/schema/stryker-core.json
+++ b/packages/api/schema/stryker-core.json
@@ -267,6 +267,7 @@
         { "$ref": "#/definitions/ArrayDeclaration" },
         { "$ref": "#/definitions/AssignmentOperator" },
         { "$ref": "#/definitions/BlockStatement" },
+        { "$ref": "#/definitions/ArrowFunction"},
         { "$ref": "#/definitions/BooleanLiteral" },
         { "$ref": "#/definitions/ConditionalExpression" },
         { "$ref": "#/definitions/EqualityOperator" },
@@ -418,21 +419,8 @@
       ]
     },
     "ArrowFunction": {
-      "title": "ArrowFunction",
-      "type": "array",
-      "description": "Mutates bodies of arrow functions to undefined",
-      "uniqueItems": true,
-      "default": [],
-      "minItems": 1,
-      "items": {
-        "anyOf": [
-          {
-            "const": "BodyToUndefined",
-            "title": "BodyToUndefinedMutator",
-            "description": "Replace body to ```undefined```."
-          }
-        ]
-      }
+      "const": "ArrowFunction",
+      "description": "Mutates bodies of arrow functions to undefined"
     },
     "BlockStatement": {
       "const": "BlockStatement",

--- a/packages/instrumenter/src/mutation-level/mutation-level.ts
+++ b/packages/instrumenter/src/mutation-level/mutation-level.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import {
   ArithmeticOperator,
   ArrayDeclaration,
+  ArrowFunction,
   AssignmentOperator,
   BlockStatement,
   BooleanLiteral,
@@ -27,14 +28,15 @@ export interface MutationLevel {
   ArithmeticOperator?: ArithmeticOperator[];
   ArrayDeclaration?: ArrayDeclaration[];
   AssignmentOperator?: AssignmentOperator[];
-  BlockStatement?: BlockStatement;
+  ArrowFunction?: ArrowFunction[];
+  BlockStatement?: BlockStatement[];
   BooleanLiteral?: BooleanLiteral[];
   ConditionalExpression?: ConditionalExpression[];
   EqualityOperator?: EqualityOperator[];
   MethodExpression?: MethodExpression[];
   ObjectLiteral?: ObjectLiteralMutator[];
   OptionalChaining?: OptionalChaining[];
-  Regex?: Regex;
+  Regex?: Regex[];
   StringLiteral?: StringLiteral[];
   UnaryOperator?: UnaryOperator[];
   UpdateOperator?: UpdateOperator[];

--- a/packages/instrumenter/src/mutators/arrow-function-mutator.ts
+++ b/packages/instrumenter/src/mutators/arrow-function-mutator.ts
@@ -7,13 +7,18 @@ import { NodeMutator } from './index.js';
 export const arrowFunctionMutator: NodeMutator = {
   name: 'ArrowFunction',
 
-  *mutate(path) {
+  *mutate(path, options) {
     if (
       path.isArrowFunctionExpression() &&
       !types.isBlockStatement(path.node.body) &&
-      !(types.isIdentifier(path.node.body) && path.node.body.name === 'undefined')
+      !(types.isIdentifier(path.node.body) && path.node.body.name === 'undefined') &&
+      isInMutationLevel(options)
     ) {
       yield types.arrowFunctionExpression([], types.identifier('undefined'));
     }
   },
 };
+
+function isInMutationLevel(operations: string[] | undefined): boolean {
+  return operations === undefined || operations.length > 0;
+}

--- a/packages/instrumenter/test/unit/mutators/arrow-function-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/arrow-function-mutator.spec.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 
+import { MutationLevel } from '@stryker-mutator/api/core';
+
 import { arrowFunctionMutator as sut } from '../../../src/mutators/arrow-function-mutator.js';
-import { expectJSMutation } from '../../helpers/expect-mutation.js';
+import { expectJSMutation, expectJSMutationWithLevel } from '../../helpers/expect-mutation.js';
+
+const arrowFunctionLevel: MutationLevel = { name: 'ArrowFunctionLevel', ArrowFunction: ['BodyToUndefined'] };
+const arrowFunctionUndefinedLevel: MutationLevel = { name: 'ArrowFunctionLevel' };
 
 describe(sut.name, () => {
   it('should have name "ArrowFunction"', () => {
@@ -18,5 +23,17 @@ describe(sut.name, () => {
 
   it('should not mutate an anonymous function with undefined as a body', () => {
     expectJSMutation(sut, 'const b = () => undefined');
+  });
+
+  it('should only mutate what is defined in the mutator level', () => {
+    expectJSMutationWithLevel(sut, arrowFunctionLevel.ArrowFunction, 'const b = () => 4;', 'const b = () => undefined;');
+  });
+
+  it('should not mutate anything if there are no values in the mutation level', () => {
+    expectJSMutationWithLevel(sut, [], 'const b = () => 4;');
+  });
+
+  it('should mutate everything if the mutation level is undefined', () => {
+    expectJSMutationWithLevel(sut, arrowFunctionUndefinedLevel.ArrowFunction, 'const b = () => 4;', 'const b = () => undefined;');
   });
 });

--- a/packages/instrumenter/test/unit/mutators/arrow-function-mutator.spec.ts
+++ b/packages/instrumenter/test/unit/mutators/arrow-function-mutator.spec.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
 
-import { MutationLevel } from '@stryker-mutator/api/core';
-
 import { arrowFunctionMutator as sut } from '../../../src/mutators/arrow-function-mutator.js';
 import { expectJSMutation, expectJSMutationWithLevel } from '../../helpers/expect-mutation.js';
+import { MutationLevel } from '../../../src/mutation-level/mutation-level.js';
 
-const arrowFunctionLevel: MutationLevel = { name: 'ArrowFunctionLevel', ArrowFunction: ['BodyToUndefined'] };
+const arrowFunctionLevel: MutationLevel = { name: 'ArrowFunctionLevel', ArrowFunction: ['ArrowFunction'] };
 const arrowFunctionUndefinedLevel: MutationLevel = { name: 'ArrowFunctionLevel' };
 
 describe(sut.name, () => {


### PR DESCRIPTION
Closes #19 

Thought about adding this:
```ts
const assignmentOperatorReplacements = Object.freeze({
  '[^]*': { replacement: 'undefined', mutatorName: 'BodyToUndefined' },
} as const);
```
Which is a regex that matches everything, because right now, it doesn't matter what's actually in the body.

I rejected that idea, because:
1. There seems to be no way to get the body of the arrow expression as a string, so you cannot perform regular expressions over it;
2. This doesn't seem to be the approach they would want, given that they use functions to determine the type of thing that is in the body, not matching a string or something.

I also thought of using class names as keys, like this:
```ts
const assignmentOperatorReplacements = Object.freeze({
  Object: { replacement: 'undefined', mutatorName: 'AnyBodyToUndefined' },
} as const);
```
The above replacement would allow anything to be set to undefined. Alternatives might be `BlockStatement`. The idea is that I check the type of body or its contents against the key of the selected level using
```ts
return operations.some((op) => body instanceof Object.create(this.context[op].prototype));
```
However, I could not get this to work. Online threads suggest using `this.context` or `window`, both of which are not applicable here (`this` doesn't mean anything outside of a class and `window` doesn't work if the application does not run in a browser).

I'm also assuming here that the keys in this array must be strings and that we can't just use class names. Using the second code snippet (the one with `Object:`), I tried using this in `isInMutationLevel`:
```ts
  if (operations === undefined) {
    return true;
  }
  return operations.some((op: any) => body instanceof op);
```
Which seems like it should work, because `body` is always an instance of `Object` (anything is). It builds, but upon running tests I get the error `TypeError: Right-hand side of 'instanceof' is not an object`.

I'd be happy to discuss this further, but for now, I simply check whether there is anything in the level at all.